### PR TITLE
Fix word wrapping in Incident Form view

### DIFF
--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -189,6 +189,11 @@ header > .navbar ul.navbar-nav > li > a {
     margin-bottom: 0 !important;
   }
 }
+
+/* Customize bootstrap .row to break really long words */
+.row {
+  word-wrap: break-word;
+}
 /* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
    all your sass files automatically */
 // injector

--- a/src/app/index.scss
+++ b/src/app/index.scss
@@ -190,9 +190,12 @@ header > .navbar ul.navbar-nav > li > a {
   }
 }
 
-/* Customize bootstrap .row to break really long words */
+/* Customize bootstrap to break really long words */
 .row {
   word-wrap: break-word;
+}
+td.ng-binding {
+  word-break: break-word;
 }
 /* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
    all your sass files automatically */


### PR DESCRIPTION
Fix word wrapping for really long names that don't have breaks, https://github.com/igarape/copcast-admin/issues/249

<img width="1081" alt="screen shot 2016-05-10 at 6 09 26 pm" src="https://cloud.githubusercontent.com/assets/6494307/15164172/10bad0ee-16db-11e6-973f-2d1c45811431.png">

Note for some screens that use tables word wrapping doesn't occur but instead the column just gets wider (still readable but may require the user to scroll right), e.g. from the "Users" screen:
![screen shot 2016-05-10 at 6 14 02 pm](https://cloud.githubusercontent.com/assets/6494307/15164183/32583598-16db-11e6-8d3e-f0ef6f40f879.png)