### PR TITLE
Display times as ##h

### DIFF
--- a/src/app/history/timeline/segment.directive.js
+++ b/src/app/history/timeline/segment.directive.js
@@ -36,7 +36,7 @@ app.directive('timelineSegment', function($timeout, $window, timelineService) {
     require: '^timelineSegments',
     templateUrl: 'app/history/timeline/segment.html',
     scope: {
-      timeLabel: '=',
+      hour: '=',
       last: '=',
       day: '=',
       activities: '=',
@@ -114,15 +114,22 @@ app.directive('timelineSegment', function($timeout, $window, timelineService) {
 
       function getIncidentsInThisHour(){
         try {
-          return scope.incidentsByDay.getMap().get(scope.day).getMap().get(scope.timeLabel);
+          return scope.incidentsByDay.getMap().get(scope.day).getMap().get(scope.hour);
         } catch (err) {
           return [];
         }
       }
       scope.getIncidentsInThisHour = getIncidentsInThisHour;
 
+      function hourToTimeLabel(hourNum) {
+        var hourString = hourNum < 10 ? '0' + hourNum : hourNum.toString();
+        return hourString + 'h';
+      }
+      scope.timeLabel = function timeLabel() {
+        return hourToTimeLabel(parseInt(scope.hour, 10));
+      };
       scope.nextTimeLabel = function nextTimeLabel() {
-        return parseInt(scope.timeLabel) + 1;
+        return hourToTimeLabel(parseInt(scope.hour, 10) + 1);
       };
 
       scope.selectPosition = function selectPosition(event, firstSectionLocation) {

--- a/src/app/history/timeline/segment.html
+++ b/src/app/history/timeline/segment.html
@@ -1,5 +1,5 @@
 <div class="segment">
-  <div class="time" ng-bind-html="timeLabel"></div>
+  <div class="time" ng-bind-html="timeLabel()"></div>
   <div class="time last" ng-bind-html="nextTimeLabel()" ng-if="last"></div>
   <div class="line"></div>
 

--- a/src/app/history/timeline/segments.html
+++ b/src/app/history/timeline/segments.html
@@ -18,7 +18,7 @@
 
     <timeline-segment
       activities="activities"
-      time-label="hour"
+      hour="hour"
       day="key"
       incidents-by-day="userData.incidentsByDay"
       last="$last"


### PR DESCRIPTION
Fixes https://github.com/igarape/copcast-admin/issues/246

Timeline now displays in ##h format, for example:
<img width="941" alt="screen shot 2016-05-19 at 2 48 24 pm" src="https://cloud.githubusercontent.com/assets/6494307/15403745/d4fb5252-1dd0-11e6-8c0d-9072a189c717.png">
