### PR TITLE
Fix timeline (Iterate over sorted arrays rather than objects in ng-repeat)

### DIFF
--- a/src/app/history/timeline/segment.html
+++ b/src/app/history/timeline/segment.html
@@ -7,7 +7,7 @@
     style="left: {{getLocationPosition(activityLocations[0])}}px;
            width: {{getLocationPosition(activityLocations[1]) - getLocationPosition(activityLocations[0])}}px;"
     ng-click="selectPosition($event, activityLocations[0]);"
-    ng-repeat="(key, activityLocations) in activities.getMap()">
+    ng-repeat="activityLocations in activities.getSortedArray()">
     <div class="line">
     </div>
   </div>

--- a/src/app/history/timeline/segments.directive.js
+++ b/src/app/history/timeline/segments.directive.js
@@ -109,6 +109,7 @@ app.directive('timelineSegments', function TimelineSegments($timeout, $window) {
           var hour = hours[i];
           var locations = locationsByHour.get(hour);
           var activities = createActivities(locations);
+          activities.hour = hour;
           activitiesByHour.put(hour, activities);
         }
         return activitiesByHour;
@@ -124,6 +125,7 @@ app.directive('timelineSegments', function TimelineSegments($timeout, $window) {
             var date = dates[i];
             var locationsByHour = locationsByDay.get(date);
             var activitiesByHour = createActivitiesByHour(locationsByHour.getMap());
+            activitiesByHour.day = date;
             activitiesByDay.put(date, activitiesByHour);
           }
           scope.userData.timeline.activitiesByDay = activitiesByDay;

--- a/src/app/history/timeline/segments.html
+++ b/src/app/history/timeline/segments.html
@@ -2,7 +2,7 @@
   <div class="selected line" style="left: {{selectedPosition}}px;">
     <img src="assets/images/scrubber.png">
   </div>
-  <div class="date segments" ng-repeat="(key, activitiesByHour) in activitiesByDay.getMap()">
+  <div class="date segments" ng-repeat="activitiesByHour in activitiesByDay.getSortedArray()">
     <!--
     <div class="start segment" ng-if="$first">
       <div class="line"></div>
@@ -10,19 +10,19 @@
     -->
 
     <div class="gap segment">
-      <div class="first date" ng-bind-html="$first ? '' : getPreviousDateLabel(key)"></div>
-      <div class="last date" ng-bind-html="getCurrentDateLabel(key)"></div>
+      <div class="first date" ng-bind-html="$first ? '' : getPreviousDateLabel(activitiesByHour.day)"></div>
+      <div class="last date" ng-bind-html="getCurrentDateLabel(activitiesByHour.day)"></div>
       <div class="line"></div>
       <div class="box"></div>
     </div>
 
     <timeline-segment
       activities="activities"
-      hour="hour"
-      day="key"
+      hour="activities.hour"
+      day="activitiesByHour.day"
       incidents-by-day="userData.incidentsByDay"
       last="$last"
-      ng-repeat="(hour, activities) in activitiesByHour.getMap()">
+      ng-repeat="activities in activitiesByHour.getSortedArray()">
     </timeline-segment>
 
     <div class="end segment" ng-if="$last">

--- a/src/app/utils/listmap.js
+++ b/src/app/utils/listmap.js
@@ -61,6 +61,10 @@
 
     getMap: function getMap() {
       return this._map.getMap();
+    },
+
+    getSortedArray: function getSortedArray() {
+      return this._map.getSortedArray();
     }
   };
 

--- a/src/app/utils/map.js
+++ b/src/app/utils/map.js
@@ -19,7 +19,7 @@
     },
 
     keys: function keys() {
-      return Object.keys(this._map);
+      return Object.keys(this._map).sort();
     },
 
     size: function size() {
@@ -47,6 +47,16 @@
 
     getMap: function getMap() {
       return this._map;
+    },
+
+    getSortedArray: function getSortedArray() {
+      var map = this.getMap();
+      var sortedKeys = Object.keys(map).sort();
+      var sortedValues = [];
+      for (var i = 0; i < sortedKeys.length; ++i) {
+        sortedValues.push(map[sortedKeys[i]]);
+      }
+      return sortedValues;
     }
   };
 


### PR DESCRIPTION
Fixes https://github.com/igarape/copcast-admin/issues/246 by iterating over sorted arrays rather than objects in ng-repeat