### PR TITLE
Show alerts when a user disconnects and reconnects, if that user is currently being watched in realtime

### DIFF
--- a/src/app/realtime/realtime.controller.js
+++ b/src/app/realtime/realtime.controller.js
@@ -441,6 +441,30 @@ angular.module('copcastAdminApp').
         user.marker.setIcon(mapService.getGreyMarker(user.userName));
       });
 
+      socket.off('userDisconnected');
+      socket.on('userDisconnected', function(data){
+        if ($scope.watchingUserId == data.userId) {
+          notify({
+            templateUrl: 'app/views/notifications/warningNotification.html',
+            message: data.name + ' ' + gettextCatalog.getString('has been disconnected.'),
+            position: 'right',
+            duration: 5000
+          });
+        }
+      });
+
+      socket.off('userReconnected');
+      socket.on('userReconnected', function(data){
+        if ($scope.watchingUserId == data.userId) {
+          notify({
+            templateUrl: 'app/views/notifications/warningNotification.html',
+            message: data.name + ' ' + gettextCatalog.getString('has been reconnected.'),
+            position: 'right',
+            duration: 5000
+          });
+        }
+      });
+
       socket.off('missionResumed');
       socket.on('missionResumed', function(data){
         var user = $scope.getCurrentUsers().getUser(data.userId);

--- a/src/po/template.pot
+++ b/src/po/template.pot
@@ -861,6 +861,14 @@ msgstr ""
 msgid "has paused the mission."
 msgstr ""
 
+#: app/realtime/realtime.controller.js:449
+msgid "has been disconnected."
+msgstr ""
+
+#: app/realtime/realtime.controller.js:461
+msgid "has been reconnected."
+msgstr ""
+
 #: app/realtime/realtime.controller.js:452
 msgid "has resumed the mission."
 msgstr ""


### PR DESCRIPTION
Show alerts when a user disconnects and reconnects, if that user is currently being watched in realtime, for #292.  This also depends on server side changes https://github.com/igarape/copcast-server/pull/89 and Android changes https://github.com/igarape/copcast-android/pull/177.

Also note I haven't yet translated this into Portugese (it looks like I need to modify the pt_BR.po and pt_BR.js files), can someone from Igarape help with that translation?  Thanks!